### PR TITLE
Add batch fetch error handling

### DIFF
--- a/Stockbar/Data/DataModel.swift
+++ b/Stockbar/Data/DataModel.swift
@@ -85,14 +85,14 @@ class DataModel: ObservableObject {
              }
 
             // Update each trade with its corresponding result
-            for result in results {
-                // Find index on main thread to avoid race conditions if trades array changes
-                if let index = self.realTimeTrades.firstIndex(where: { $0.trade.name == result.symbol }) {
-                    // Ensure update happens on main thread
-                    self.realTimeTrades[index].updateWithResult(result)
-                    logger.debug("Updated trade \(result.symbol) from refresh result.")
+            let resultDict = Dictionary(uniqueKeysWithValues: results.map { ($0.symbol, $0) })
+            for idx in self.realTimeTrades.indices {
+                let symbol = self.realTimeTrades[idx].trade.name
+                if let res = resultDict[symbol] {
+                    self.realTimeTrades[idx].updateWithResult(res)
+                    logger.debug("Updated trade \(symbol) from refresh result.")
                 } else {
-                    logger.warning("Received result for symbol \(result.symbol) but no matching trade found.")
+                    logger.warning("No result returned for symbol \(symbol).")
                 }
             }
             logger.info("Successfully refreshed \(results.count) trades of \(symbols.count) requested.")

--- a/Stockbar/Networking/NetworkService.swift
+++ b/Stockbar/Networking/NetworkService.swift
@@ -119,35 +119,86 @@ class PythonNetworkService: NetworkService {
     func fetchBatchQuotes(for symbols: [String]) async throws -> [StockFetchResult] {
         logger.info("Starting batch fetch for \(symbols.count) symbols using Python script.")
 
-        return try await withThrowingTaskGroup(of: StockFetchResult?.self) { group in
-            for sym in symbols {
-                group.addTask {
-                    do {
-                        return try await self.fetchQuote(for: sym)
-                    } catch {
-                        self.logger.warning("Failed to fetch quote for symbol '\(sym)': \(error.localizedDescription)")
-                        return nil
-                    }
-                }
-            }
+        guard !symbols.isEmpty else { return [] }
 
-            var results: [StockFetchResult] = []
-            var lastError: Error?
-            for try await res in group {
-                if let result = res {
-                    results.append(result)
-                } else {
-                    lastError = lastError ?? NetworkError.noData("No result for symbol")
-                }
-            }
-
-            if results.isEmpty, let err = lastError {
-                logger.error("Batch fetch failed for all symbols. Last error: \(err.localizedDescription)")
-                throw err
-            }
-
-            logger.info("Finished batch fetch. Successfully fetched \(results.count) of \(symbols.count) symbols.")
-            return results
+        guard let scriptPath = Bundle.main.path(forResource: scriptName.replacingOccurrences(of: ".py", with: ""), ofType: "py") else {
+            logger.error("Script '\(scriptName)' not found in bundle.")
+            throw NetworkError.scriptNotFound(scriptName)
         }
+
+        guard FileManager.default.fileExists(atPath: pythonInterpreterPath) else {
+            logger.error("Python interpreter not found at \(pythonInterpreterPath)")
+            throw NetworkError.pythonInterpreterNotFound(pythonInterpreterPath)
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: pythonInterpreterPath)
+        process.arguments = [scriptPath, symbols.joined(separator: ",")]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+
+        if let err = String(data: errorData, encoding: .utf8), !err.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            logger.error("Python script stderr (batch): \(err)")
+        }
+
+        guard let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !output.isEmpty else {
+            logger.warning("Python script stdout for batch is empty.")
+            throw NetworkError.noData("Empty output from batch script")
+        }
+
+        logger.debug("Python script batch stdout: \(output)")
+
+        var results: [StockFetchResult] = []
+        for line in output.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+
+            let parts = trimmed.split(separator: ",")
+
+            if parts.count == 2 && parts[1] == "FETCH_FAILED" {
+                logger.warning("Batch fetch failed for symbol \(parts[0]).")
+                continue
+            }
+
+            guard parts.count == 3 else {
+                logger.warning("Invalid line in batch output: \(trimmed)")
+                continue
+            }
+
+            let symbol = String(parts[0])
+            guard let price = Double(parts[1]), let prev = Double(parts[2]) else {
+                logger.warning("Could not parse numbers in batch line: \(trimmed)")
+                continue
+            }
+
+            let result = StockFetchResult(
+                currency: nil,
+                symbol: symbol,
+                shortName: symbol,
+                regularMarketTime: Int(Date().timeIntervalSince1970),
+                exchangeTimezoneName: nil,
+                regularMarketPrice: price,
+                regularMarketPreviousClose: prev
+            )
+
+            results.append(result)
+        }
+
+        if results.isEmpty {
+            logger.warning("Batch fetch produced no usable results.")
+            return []
+        }
+
+        logger.info("Finished batch fetch. Successfully fetched \(results.count) of \(symbols.count) symbols.")
+        return results
     }
 }


### PR DESCRIPTION
## Summary
- suppress urllib3 warning and silence info message from yfinance
- filter FETCH_FAILED results and ignore empty lines in batch fetch
- return empty array instead of throwing if all tickers fail

## Testing
- `python3 -m py_compile Stockbar/Resources/get_stock_data.py`