### PR TITLE
Add batch fetching support

### DIFF
--- a/Stockbar/Data/DataModel.swift
+++ b/Stockbar/Data/DataModel.swift
@@ -85,14 +85,14 @@ class DataModel: ObservableObject {
              }
 
             // Update each trade with its corresponding result
-            for result in results {
-                // Find index on main thread to avoid race conditions if trades array changes
-                if let index = self.realTimeTrades.firstIndex(where: { $0.trade.name == result.symbol }) {
-                    // Ensure update happens on main thread
-                    self.realTimeTrades[index].updateWithResult(result)
-                    logger.debug("Updated trade \(result.symbol) from refresh result.")
+            let resultDict = Dictionary(uniqueKeysWithValues: results.map { ($0.symbol, $0) })
+            for idx in self.realTimeTrades.indices {
+                let symbol = self.realTimeTrades[idx].trade.name
+                if let res = resultDict[symbol] {
+                    self.realTimeTrades[idx].updateWithResult(res)
+                    logger.debug("Updated trade \(symbol) from refresh result.")
                 } else {
-                    logger.warning("Received result for symbol \(result.symbol) but no matching trade found.")
+                    logger.warning("No result returned for symbol \(symbol).")
                 }
             }
             logger.info("Successfully refreshed \(results.count) trades of \(symbols.count) requested.")
@@ -218,6 +218,11 @@ extension RealTimeTrade {
             price = price / 100.0
             prevClose = prevClose / 100.0
             currency = "GBP"
+        }
+
+        // Fallback: if price is NaN use the previous close (seen with some US stocks)
+        if price.isNaN {
+            price = prevClose
         }
         self.realTimeInfo.currentPrice = price
         self.realTimeInfo.previousClose = prevClose

--- a/Stockbar/Resources/get_stock_data.py
+++ b/Stockbar/Resources/get_stock_data.py
@@ -3,6 +3,7 @@ import yfinance as yf
 import sys
 import warnings
 import os
+import math
 try:
     from urllib3.exceptions import NotOpenSSLWarning
     warnings.filterwarnings("ignore", category=NotOpenSSLWarning)
@@ -13,50 +14,70 @@ except ImportError:
 for proxy_var in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"]:
     os.environ.pop(proxy_var, None)
 
-def get_data(ticker_symbol):
-    """Fetches current price, previous close, currency, and timestamp for a ticker using yfinance."""
+def fetch_batch(symbols):
+    """Fetch closing and previous closing prices for a list of symbols."""
     try:
-        stock = yf.Ticker(ticker_symbol)
-        hist = stock.history(period="2d")
-        stock_info = stock.info
-        current_price = None
-        prev_close = None
-        currency = None
-        timestamp = None
+        ticker_str = " ".join(symbols)
+        data = yf.download(
+            ticker_str,
+            period="2d",
+            group_by="ticker",
+            threads=False,
+            progress=False,
+        )
 
-        if hist.empty or len(hist) < 1:
-            if stock_info and 'symbol' in stock_info:
-                current_price = stock_info.get('currentPrice', stock_info.get('regularMarketPrice'))
-                prev_close = stock_info.get('previousClose')
-                currency = stock_info.get('currency')
-                timestamp = stock_info.get('regularMarketTime')
-            else:
-                return None, None, None, None
-        else:
-            current_price = hist['Close'].iloc[-1]
-            prev_close = hist['Close'].iloc[-2] if len(hist) > 1 else hist['Open'].iloc[-1]
-            currency = stock_info.get('currency')
-            timestamp = stock_info.get('regularMarketTime')
+        results = {}
+        for sym in symbols:
+            try:
+                sym_data = data[sym] if len(symbols) > 1 else data
+            except Exception:
+                sym_data = None
 
-        if current_price is not None and prev_close is not None and currency is not None and timestamp is not None:
-            return float(current_price), float(prev_close), str(currency), int(timestamp)
-        else:
-            return None, None, None, None
+            if sym_data is None or sym_data.empty:
+                results[sym] = None
+                continue
 
+            close_series = sym_data["Close"]
+            current_price = close_series.iloc[-1]
+            prev_close = (
+                close_series.iloc[-2]
+                if len(close_series) > 1
+                else sym_data["Open"].iloc[-1]
+            )
+
+            # Use previous close if the most recent close is NaN (common for US stocks during trading hours)
+            try:
+                cp_float = float(current_price)
+            except Exception:
+                cp_float = float('nan')
+
+            try:
+                prev_float = float(prev_close)
+            except Exception:
+                prev_float = float('nan')
+
+            if math.isnan(cp_float):
+                cp_float = prev_float
+
+            results[sym] = (cp_float, prev_float)
+
+        return results
     except Exception as e:
-        print(f"Error fetching {ticker_symbol}: {e}", file=sys.stderr)
-        return None, None, None, None
+        print(f"Error fetching batch: {e}", file=sys.stderr)
+        return {sym: None for sym in symbols}
 
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:
-        symbol = sys.argv[1]
-        price, prev_close, currency, timestamp = get_data(symbol)
-        if price is not None and prev_close is not None:
-            # Output: price,prev_close (only)
-            print(f"{price},{prev_close}")
-        else:
-            print("FETCH_FAILED")
+        symbols = sys.argv[1].split(",")
+        batch = fetch_batch(symbols)
+        for sym in symbols:
+            result = batch.get(sym)
+            if result:
+                price, prev_close = result
+                print(f"{sym},{price},{prev_close}")
+            else:
+                print(f"{sym},FETCH_FAILED")
     else:
-        print("Usage: python get_stock_data.py <SYMBOL>", file=sys.stderr)
-        print("FETCH_FAILED") # Indicate failure due to wrong usage
+        print("Usage: python get_stock_data.py <SYMBOL[,SYMBOL...]>", file=sys.stderr)
+


### PR DESCRIPTION
## Summary
- update the helper Python script to fetch multiple symbols at once
- parse batch output in `PythonNetworkService.fetchBatchQuotes`
- refresh all trades using a dictionary lookup
- fallback to previous close when price data is NaN

## Testing
- `python3 -m py_compile Stockbar/Resources/get_stock_data.py`
